### PR TITLE
Clear the password field after a failed login.

### DIFF
--- a/client/login-view.jsx
+++ b/client/login-view.jsx
@@ -50,7 +50,8 @@ var LoginView = React.createClass({
         request.fail(function() {
             this.setState({
                 disabled: false,
-                message: 'Invalid NetID or password.'
+                message: 'Invalid NetID or password.',
+                password: ''
             });
         }.bind(this));
         return false;


### PR DESCRIPTION
It's (currently) really annoying to have to manually clear the password field after a failed login. This fixes it. (i.e., it clears automatically).
